### PR TITLE
Replace hard-coded branch names with $default-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Links:
 
 ## workflows
 ### gradle
- * [workflow-templates/gradle/pull-request.yml](workflow-templates/gradle/pull-request.yml): test and compile on pull request to master or main
+ * [workflow-templates/gradle/pull-request.yml](workflow-templates/gradle/pull-request.yml): test and compile on pull request to a branch (by default the default one)

--- a/workflow-templates/gradle/pull-request.yml
+++ b/workflow-templates/gradle/pull-request.yml
@@ -2,7 +2,7 @@ name: compile-check on pull-request to master or main
 
 on:
   pull_request:
-    branches: [ master, main ]
+    branches: [ $default-branch ]
 
 jobs:
   build:


### PR DESCRIPTION
According to https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow